### PR TITLE
update OpenBLAS to version 0.3.21

### DIFF
--- a/src/matrix/cblas-wrappers.h
+++ b/src/matrix/cblas-wrappers.h
@@ -383,10 +383,10 @@ inline void mul_elements(
 // add clapack here
 #if !defined(HAVE_ATLAS)
 inline void clapack_Xtptri(KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *result) {
-  stptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
+  stptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result, 1, 1);
 }
 inline void clapack_Xtptri(KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *result) {
-  dtptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
+  dtptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result, 1, 1);
 }
 // 
 inline void clapack_Xgetrf2(KaldiBlasInt *num_rows, KaldiBlasInt *num_cols, 
@@ -420,7 +420,7 @@ inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
   sgesvd_(v, u,
           num_cols, num_rows, Mdata, stride,
           sv, Vdata, vstride, Udata, ustride, 
-          p_work, l_work, result); 
+          p_work, l_work, result, 1, 1);
 }
 inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
                            KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *stride,
@@ -430,25 +430,25 @@ inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
   dgesvd_(v, u,
           num_cols, num_rows, Mdata, stride,
           sv, Vdata, vstride, Udata, ustride,
-          p_work, l_work, result); 
+          p_work, l_work, result, 1, 1);
 }
 //
 void inline clapack_Xsptri(KaldiBlasInt *num_rows, float *Mdata, 
                            KaldiBlasInt *ipiv, float *work, KaldiBlasInt *result) {
-  ssptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
+  ssptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result, 1);
 }
 void inline clapack_Xsptri(KaldiBlasInt *num_rows, double *Mdata, 
                            KaldiBlasInt *ipiv, double *work, KaldiBlasInt *result) {
-  dsptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
+  dsptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result, 1);
 }
 //
 void inline clapack_Xsptrf(KaldiBlasInt *num_rows, float *Mdata,
                            KaldiBlasInt *ipiv, KaldiBlasInt *result) {
-  ssptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
+  ssptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result, 1);
 }
 void inline clapack_Xsptrf(KaldiBlasInt *num_rows, double *Mdata,
                            KaldiBlasInt *ipiv, KaldiBlasInt *result) {
-  dsptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
+  dsptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result, 1);
 }
 #else
 inline void clapack_Xgetrf(MatrixIndexT num_rows, MatrixIndexT num_cols,

--- a/tools/extras/install_openblas_clapack.sh
+++ b/tools/extras/install_openblas_clapack.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-OPENBLAS_VERSION=0.3.20
+OPENBLAS_VERSION=0.3.21
 CLAPACK_VERSION=3.2.1
 
 git clone -b v${OPENBLAS_VERSION} --single-branch https://github.com/xianyi/OpenBLAS


### PR DESCRIPTION
I tested this by compiling libvosk.so and testing a cgo vosk program.

This enables me to package vosk for Void Linux using the preexisting `openblas-devel` package. Thank you.

Closes https://github.com/alphacep/vosk-api/issues/1134