### PR TITLE
arm64 support

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -78,7 +78,11 @@ else ifeq ($(OS),Windows_NT)
   # This new OS path is confirmed working on Windows 10 / Cygwin64.
   openfst_add_CXXFLAGS = -g -O2 -Wa,-mbig-obj
 else
-  openfst_add_CXXFLAGS = -g -O3 -msse -msse2
+  openfst_add_CXXFLAGS = -g -O3
+  ARCH := $(shell uname -m)
+  ifeq ($(ARCH), x86_64)
+    openfst_add_CXXFLAGS += -msse -msse2
+  endif
 endif
 
 openfst-$(OPENFST_VERSION)/Makefile: openfst-$(OPENFST_VERSION)
@@ -89,7 +93,7 @@ openfst-$(OPENFST_VERSION)/Makefile: openfst-$(OPENFST_VERSION)
 		LDFLAGS="$(LDFLAGS)" LIBS="-ldl"
 
 openfst-$(OPENFST_VERSION):
-	git clone --single-branch https://github.com/alphacep/openfst openfst-$(OPENFST_VERSION)
+	git clone -b arm64 --single-branch https://github.com/darkdragon-001/openfst openfst-$(OPENFST_VERSION)
 
 openfst_cleaned:
 	-for d in openfst/ openfst-*/; do \

--- a/tools/extras/install_openblas_clapack.sh
+++ b/tools/extras/install_openblas_clapack.sh
@@ -9,7 +9,7 @@ git clone -b v${CLAPACK_VERSION} --single-branch https://github.com/alphacep/cla
 make -C OpenBLAS ONLY_CBLAS=1 DYNAMIC_ARCH=1 TARGET=NEHALEM USE_LOCKING=1 USE_THREAD=0 NUM_THREADS=512 all
 make -C OpenBLAS PREFIX=$(pwd)/OpenBLAS/install install
 mkdir -p clapack/BUILD && cd clapack/BUILD && cmake .. \
-    && make -j 10 -C F2CLIBS \
-    && make -j 10 -C BLAS \
-    && make -j 10 -C SRC \
+    && make -j $(nproc) -C F2CLIBS \
+    && make -j $(nproc) -C BLAS \
+    && make -j $(nproc) -C SRC \
     && find . -name "*.a" | xargs cp -t ../../OpenBLAS/install/lib


### PR DESCRIPTION
- `arm64` doesn't support SSE, so making those flags conditional.
- Use `nproc` instead of hard-coded `10` to allow building on machines with fewer cores

This is part of a my effort to enable arm64 builds in vosk:
- https://github.com/alphacep/openfst/pull/4
- https://github.com/alphacep/kaldi/pull/8
- https://github.com/alphacep/vosk-server/pull/270